### PR TITLE
Require distro system widely used for similar source

### DIFF
--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -30,9 +30,9 @@ software as of my latest contribution.
    part of a larger program.
 
 To release source code, publish the preferred form for making
-changes through a widely used, freely accessible source code
-distribution system, and license it on terms at least as
-permissive as this license. If source code has already been
+changes through a freely accessible distribution system widely
+used for similar source code, and license it on terms at least
+as permissive as this license. If source code has already been
 released, you do not have to release it again.
 
 You are excused for unknowingly breaking 1, 2, or 3 if you


### PR DESCRIPTION
I think this approach helps to narrow the requirement more toward its purpose, which is making it practical for developers looking for source to find it, without taking a technology-specific approach, as did #5.