### PR TITLE
Use "contribute" instead of "release"

### DIFF
--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -5,19 +5,19 @@ Copyright Notice: {{{name}}}
 Source Notice: {{{source}}}
 
 This license lets you use and share this software for free, as
-long as you release any software you make with it. Specifically:
+long as you contribute any software you make with it. Specifically:
 
 If you follow the rules below, you may do everything with this
 software that would otherwise infringe either my copyright in it,
 any patent claim I can license that covers this software as of my
 latest contribution, or both.
 
-1. Release source code for changes you make to this software.
+1. Contribute source code for changes you make to this software.
 
 2. If you run or combine this software with other software in
-   any larger program, release all source code for that program.
+   any larger program, contribute all source code for that program.
 
-3. Release all source code for software whose source code
+3. Contribute all source code for software whose source code
    you write, change, or analyze with this software.
 
 4. Ensure everyone who gets a copy of this software from you,
@@ -29,14 +29,14 @@ latest contribution, or both.
    alone, accusing this software, with or without changes,
    alone or as part of a larger program.
 
-To release source code, publish the preferred form for making
+To contribute source code, publish the preferred form for making
 changes through a freely accessible distribution system widely
 used for similar source code, and license contributions not
 already licensed to the public on terms as permissive as this
 license accordingly.
 
 You are excused for unknowingly breaking 1, 2, or 3 if you
-release source code, or stop doing anything requiring this
+contribute source code, or stop doing anything requiring this
 license, within 30 days of learning you broke the rule.
 
 **This software comes as is, without any warranty at all. As far

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -5,7 +5,7 @@ Copyright Notice: {{{name}}}
 Source Notice: {{{source}}}
 
 This license lets you use and share this software for free, as
-long as you contribute any software you make with it. Specifically:
+long as you contribute software you make with it. Specifically:
 
 If you follow the rules below, you may do everything with this
 software that would otherwise infringe either my copyright in it,
@@ -14,8 +14,8 @@ latest contribution, or both.
 
 1. Contribute source code for changes you make to this software.
 
-2. If you run or combine this software with other software in
-   any larger program, contribute all source code for that program.
+2. If you run or combine this software with other software in any
+   larger program, contribute all source code for that program.
 
 3. Contribute all source code for software whose source code
    you write, change, or analyze with this software.


### PR DESCRIPTION
The primary meaning of contribute seems right on point:

> to give or supply in common with others - _contribute money to a cause_

As others have pointed out, "release" can be read to mean primarily, or only, publishing source code.  Under Parity, as under other share-alike licenses, the requirement goes beyond publication, to licensing.