### PR TITLE
Version 5.0.0

### DIFF
--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -2,7 +2,7 @@ The Parity Public License {{{version}}}
 
 Contributor: {{{name}}}
 
-Source Code Address: {{{source}}}
+Source Code: {{{source}}}
 
 This license lets you use and share this software for free, as
 long as you contribute software you make with it. Specifically:
@@ -23,7 +23,7 @@ contribution, or both.
 
 4. Ensure everyone who gets a copy of this software from you,
    in source code or any other form, gets the text of this
-   license and the contributor and source code notices above.
+   license and the contributor and source code lines above.
 
 5. Do not make any legal claim against anyone for infringing
    any patent claim they would infringe by using this software

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -1,6 +1,6 @@
 The Parity Public License {{{version}}}
 
-Copyright Notice: {{{name}}}
+Contributor: {{{name}}}
 
 Source Notice: {{{source}}}
 
@@ -8,9 +8,10 @@ This license lets you use and share this software for free, as
 long as you contribute software you make with it. Specifically:
 
 If you follow the rules below, you may do everything with this
-software that would otherwise infringe either my copyright in it,
-any patent claim I can license that covers this software as of my
-latest contribution, or both.
+software that would otherwise infringe either the contributor's
+copyright in it, any patent claim the contributor can license
+that covers this software as of the contributor's latest
+contribution, or both.
 
 1. Contribute changes you make to this software.
 
@@ -22,7 +23,7 @@ latest contribution, or both.
 
 4. Ensure everyone who gets a copy of this software from you,
    in source code or any other form, gets the text of this
-   license and the copyright and source notices above.
+   license and the contributor and source notices above.
 
 5. Do not make any legal claim against anyone for infringing
    any patent claim they would infringe by using this software
@@ -40,5 +41,6 @@ contribute the software, or stop doing anything requiring this
 license, within 30 days of learning you broke the rule.
 
 **This software comes as is, without any warranty at all. As far
-as the law allows, I will not be liable for any damages related
-to this software or this license, for any kind of legal claim.**
+as the law allows, the contributor will not be liable for any
+damages related to this software or this license, for any kind of
+legal claim.**

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -37,7 +37,7 @@ license contributions not already licensed to the public on terms
 as permissive as this license accordingly.
 
 You are excused for unknowingly breaking 1, 2, or 3 if you
-contribute the software, or stop doing anything requiring this
+contribute as required, or stop doing anything requiring this
 license, within 30 days of learning you broke the rule.
 
 **This software comes as is, without any warranty at all. As far

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -2,7 +2,7 @@ The Parity Public License {{{version}}}
 
 Contributor: {{{name}}}
 
-Source Notice: {{{source}}}
+Source Code Address: {{{source}}}
 
 This license lets you use and share this software for free, as
 long as you contribute software you make with it. Specifically:
@@ -23,7 +23,7 @@ contribution, or both.
 
 4. Ensure everyone who gets a copy of this software from you,
    in source code or any other form, gets the text of this
-   license and the contributor and source notices above.
+   license and the contributor and source code notices above.
 
 5. Do not make any legal claim against anyone for infringing
    any patent claim they would infringe by using this software

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -29,11 +29,11 @@ latest contribution, or both.
    alone, accusing this software, with or without changes,
    alone or as part of a larger program.
 
-To contribute software, publish all its source code, in the preferred form for making
-changes, through a freely accessible distribution system widely
-used for similar source code, and license contributions not
-already licensed to the public on terms as permissive as this
-license accordingly.
+To contribute software, publish all its source code, in the
+preferred form for making changes, through a freely accessible
+distribution system widely used for similar source code, and
+license contributions not already licensed to the public on terms
+as permissive as this license accordingly.
 
 You are excused for unknowingly breaking 1, 2, or 3 if you
 contribute source code, or stop doing anything requiring this

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -28,7 +28,7 @@ contribution, or both.
 5. Do not make any legal claim against anyone for infringing
    any patent claim they would infringe by using this software
    alone, accusing this software, with or without changes,
-   alone or as part of a larger program.
+   alone or as part of a larger application.
 
 To contribute software, publish all its source code, in the
 preferred form for making changes, through a freely accessible

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -12,14 +12,13 @@ software that would otherwise infringe either my copyright in it,
 any patent claim I can license that covers this software as of my
 latest contribution, or both.
 
-1. Contribute source code for changes you make to this software.
+1. Contribute changes you make to this software.
 
 2. If you run or combine this software with other software as
-   part of any larger application, contribute all source code for
-   that application.
+   part of any larger application, contribute that application.
 
-3. Contribute all source code for software you develop, deploy,
-   monitor, or run with this software.
+3. Contribute software you develop, deploy, monitor, or run with
+   this software.
 
 4. Ensure everyone who gets a copy of this software from you,
    in source code or any other form, gets the text of this
@@ -30,8 +29,8 @@ latest contribution, or both.
    alone, accusing this software, with or without changes,
    alone or as part of a larger program.
 
-To contribute source code, publish the preferred form for making
-changes through a freely accessible distribution system widely
+To contribute software, publish all its source code, in the preferred form for making
+changes, through a freely accessible distribution system widely
 used for similar source code, and license contributions not
 already licensed to the public on terms as permissive as this
 license accordingly.

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -21,14 +21,14 @@ contribution, or both.
 3. Contribute software you develop, deploy, monitor, or run with
    this software.
 
-4. Ensure everyone who gets a copy of this software from you,
-   in source code or any other form, gets the text of this
-   license and the contributor and source code lines above.
+4. Ensure everyone who gets a copy of this software from you, in
+   source code or any other form, gets the text of this license
+   and the contributor and source code lines above.
 
-5. Do not make any legal claim against anyone for infringing
-   any patent claim they would infringe by using this software
-   alone, accusing this software, with or without changes,
-   alone or as part of a larger application.
+5. Do not make any legal claim against anyone for infringing any
+   patent claim they would infringe by using this software alone,
+   accusing this software, with or without changes, alone or as
+   part of a larger application.
 
 To contribute software, publish all its source code, in the
 preferred form for making changes, through a freely accessible

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -36,7 +36,7 @@ license contributions not already licensed to the public on terms
 as permissive as this license accordingly.
 
 You are excused for unknowingly breaking 1, 2, or 3 if you
-contribute source code, or stop doing anything requiring this
+contribute the software, or stop doing anything requiring this
 license, within 30 days of learning you broke the rule.
 
 **This software comes as is, without any warranty at all. As far


### PR DESCRIPTION
A few significant changes:

1. Use "contributor" instead of the first person, to gracefully handle both individual and entity licensors.
2. Refactor the meaning of "contribution" a bit, to shorten the enumerated rules, by moving the requirement to contribute source code, and all the source code, into the meaning of "contribute".

@compleatang, this will be very relevant for your use case and concerns raised in #25. I still believe individual licensors will be majority users of Parity, by number of licenses granted. But the _purpose_ of a license like this, in greater context, is also directly targeted at companies looking for strategic use of share-alike requirements. It's worth compromising a little readability to express the equal importance of that kind of use case.