### PR TITLE
Broaden patent grant to cover all licensable patents

### DIFF
--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -9,9 +9,8 @@ long as you contribute software you make with it. Specifically:
 
 If you follow the rules below, you may do everything with this
 software that would otherwise infringe either the contributor's
-copyright in it, any patent claim the contributor can license
-that covers this software as of the contributor's latest
-contribution, or both.
+copyright in it, any patent claim the contributor can license,
+or both.
 
 1. Contribute changes you make to this software.
 


### PR DESCRIPTION
Rationale:

- The vast majority of Parity licensors will not have or seek patents.

- Dual licensors using Parity will tend to consolidate IP ownership within a single entity.  A single legal contributor removes the risk of one contributor making changes that bring the combined work under another contributor's patents.

- In multi-contributor projects, patent grants with limited scope determinable only from extended development history, and then only imperfectly, don't offer licensees firm assurance.

- The patent-scope language has been the hardest to write plain and short.  Even as previously written, the rationale wasn't clear to readers unfamiliar with the specifics of patent terms in prior licenses.