### PR TITLE
Broaden defensive termination (closes #32) (closes #34)

### DIFF
--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -24,10 +24,9 @@ or both.
    source code or any other form, gets the text of this license
    and the contributor and source code lines above.
 
-5. Do not make any legal claim against anyone for infringing any
-   patent claim they would infringe by using this software alone,
-   accusing this software, with or without changes, alone or with
-   other software.
+5. Do not make any legal claim against anyone accusing this
+   software, with or without changes, alone or with other
+   software, of infringing any patent claim.
 
 To contribute software, publish all its source code, in the
 preferred form for making changes, through a freely accessible


### PR DESCRIPTION
This pull request makes Rule 5, the patent defensive termination rule, much easier to read, by making it broader and simpler.

For context, patent defensive termination rules say, in cartoon: If you sue me or my users for infringing patents, your license for this software terminates.

# Apache

Parity originally set out to mimic the relatively narrow defensive termination approach of [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0#patent):

> 3.  **Grant of Patent License**. ... If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.

Notice when it triggers:

- Who gets sued? The licensor or any licensee.
- Accusing what? The software being licensed, or a contribution incorporated into it.
- What gets terminated? Just the patent grant in the license, not the copyright grant.

# OSL

<https://opensource.org/licenses/OSL-3.0>

> 10. **Termination for Patent Action**.  This License shall terminate automatically and You may no longer exercise any of the rights granted to You by this License as of the date You commence an action, including a cross-claim or counterclaim, against Licensor or any licensee alleging that the Original Work infringes a patent.  This termination provision shall not apply for an action alleging patent infringement by combinations of the Original Work with other software or hardware.

- Who sets sued? The licensor or any licensee.
- Accusing what? The software being licensed, but not any derivatives or combinations.
- What gets terminated? Both patent and copyright grants.

# IBM's CPL 1.0

<https://www.eclipse.org/legal/cpl-v10.html>

> If Recipient institutes patent litigation against a Contributor with respect to a patent applicable to software (including a cross-claim or counterclaim in a lawsuit), then any patent licenses granted by that Contributor to such Recipient under this Agreement shall terminate as of the date such litigation is filed. In addition, if Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.

- Who gets sued? The licensor or any contributor.
- Accusing what? Any software.
- What gets terminated? Just the patent grant.

# MPL 2.0

> 5.2.  If You initiate litigation against any entity by asserting a patent infringement claim (excluding declaratory judgment actions, counter-claims, and cross-claims) alleging that a Contributor Version directly or indirectly infringes any patent, then the rights granted to You by any and all Contributors for the Covered Software under Section 2.1 of this License shall terminate.

- Who gets sued? The licensor or any licensee.
- Accusing what? The software being licensed, and any versions incorporating others' contributions.
- What gets terminated? Both patent and copyright grants.

# This Pull Request

- Who gets sued? Anybody.
- Accusing what? The licensed software, and any changed versions or combinations with other software.
- What gets terminated? Both patent and copyright grants.

---

I need to do a bit more research on the question of patent claims against changed versions and larger software systems incorporating the licensed software. The even wider breadth of the CPL provision, as well as examples like both Facebook's original and revised `PATENTS` grants, implies that this approach should be legally possible. But I want to do a bit of research on the trade-offs that led many recent licenses to exempt patent claims against derivatives of the software as provided.

Parity strong-copyleft nature raises some interesting questions there, since there's no such thing as an authorized derivative or combining system that isn't also "contributed" under a public license. The license for new contributions may be Parity or a more permissive license.