### PR TITLE
README: Add User Group and Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Parity is a public `LICENSE` for open software that requires users who build wit
 
 Parity is a [flipped form](https://flippedform.com) in everyday English.  If something doesn't make sense, that's Parity's fault, not yours.  Please [open an issue on GitHub](https://github.com/licensezero/parity-public-license/issues/new) so we can fix it.
 
+## User Group and Releases
+
+If you're using Parity for a project:
+
+[E-mail kyle@artlessdevices.com to join the private user group](mailto:kyle@artlessdevies.com?subject=Parity%20User%20Group)
+
+[Watch new releases](https://help.github.com/articles/watching-and-unwatching-releases-for-a-repository/) from the [GitHub repository for the license](https://github.com/licensezero/parity-public-license).
+
 ## Why?
 
 You might choose Parity because you're a [pragmatic idealist](https://www.gnu.org/philosophy/pragmatic.en.html) looking for a copyleft license that's evolved with the times.


### PR DESCRIPTION
Doing this as a PR primarily so folks watching can see!

This PR adds a mention right at the top of the README for users of the license.

First, I'm announcing a private user group for Parity and other L0 licenses. A number of folks using the license have expressed interest in talking with other users, and I want to facilitate that, probably through a private Discourse forum. One of the features of that forum should be a living list of public projects using Parity.

Second, GitHub recently made it possible to watch a repository _for new releases only_. I think that's a great option for Parity users who want to be notified of any changes, but don't necessarily have bandwidth for all the issues and pull requests.