### PR TITLE
Add "also" to Rule 4

### DIFF
--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -21,7 +21,7 @@ or both.
    this software.
 
 4. Ensure everyone who gets a copy of this software from you, in
-   source code or any other form, gets the text of this license
+   source code or any other form, also gets the text of this license
    and the contributor and source code lines above.
 
 5. Do not make any legal claim against anyone accusing this

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -20,9 +20,9 @@ or both.
 3. Contribute software you develop, deploy, monitor, or run with
    this software.
 
-4. Ensure everyone who gets a copy of this software from you, in
-   source code or any other form, also gets the text of this license
-   and the contributor and source code lines above.
+4. Ensure everyone who gets a copy of this software from you,
+   in source code or any other form, also gets the text of this
+   license and the contributor and source code lines above.
 
 5. Do not make any legal claim against anyone accusing this
    software, with or without changes, alone or with other


### PR DESCRIPTION
I've done a few cold reads of 6.0.0, and every time I've marked up this addition to Rule 4.

I don't think this is worth releasing a new version.  But if we come up with other edits, I'd be happy to merge it as part of a batch.