### PR TITLE
Add Rule 4 to automatic excuse list

### DIFF
--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -34,7 +34,7 @@ distribution system widely used for similar source code, and
 license contributions not already licensed to the public on terms
 as permissive as this license accordingly.
 
-You are excused for unknowingly breaking 1, 2, or 3 if you
+You are excused for unknowingly breaking 1, 2, 3, or 4 if you
 contribute as required, or stop doing anything requiring this
 license, within 30 days of learning you broke the rule.
 


### PR DESCRIPTION
This PR adds Rule 4, the attribution/notice rule, to the list of rules to which automatic excuse applies.

This would take Parity away from common practice, even among very permissive licenses.

I'm not sure about this one.  On the one hand, there's lots of latent, "copyright trolling" like behavior waiting to happen, for relatively minor breaches of notice conditions under MIT, BSD, and the rest.  On the other hand, notices should be automatic, and preferably automated, for all open source users.