### PR TITLE
Sketch Potential Version 7

### DIFF
--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -40,7 +40,7 @@ With the exception of prototypes:
 
 2.  If you combine this software with other software, contribute that software.
 
-3.  Contribute software you develop, deploy, monitor, or run with this software.
+3.  Contribute other software you develop, deploy, monitor, or run with this software.
 
 4.  When in doubt, contribute the software.
 

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -66,4 +66,4 @@ You are excused for unknowingly breaking [Copyleft](#copyleft) if you contribute
 
 ## No Liability
 
-***As far as the law allows, this software comes as is, without any warranty or condition, and the contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***
+***As far as the law allows, this software comes as is, without any warranty or condition, and the contributor will not be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -66,7 +66,7 @@ With the exception of prototypes:
 
 You need not contribute prototype changes, extensions,
 or other software that you do not end up using for more
-than fourteen calendar days, sharing with anyone else,
+than thirty calendar days, sharing with anyone else,
 or using to provide a service to anyone else.
 
 ## Contributing

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -1,44 +1,105 @@
-The Parity Public License {{{version}}}
+# The Parity Public License {{{version}}}
 
 Contributor: {{{name}}}
 
 Source Code: {{{source}}}
 
-This license lets you use and share this software for free, as
-long as you contribute software you make with it. Specifically:
+## Purpose
 
-If you follow the rules below, you may do everything with this
-software that would otherwise infringe either the contributor's
-copyright in it, any patent claim the contributor can license,
-or both.
+This license lets you use and share this software for
+free, as long as you contribute software you make with it,
+other than prototypes.
 
-1. Contribute changes and additions you make to this software.
+## Acceptance
 
-2. If you combine this software with other software, contribute
-   that other software.
+In order to receive this license, you must agree to its
+rules.  The rules of this license are both obligations
+under that agreement and conditions to your license.
+You must not do anything with this software that triggers
+a rule that you cannot or will not follow.
 
-3. Contribute software you develop, deploy, monitor, or run with
-   this software.
+## Copyright
 
-4. Ensure everyone who gets a copy of this software from you, in
-   source code or any other form, gets the text of this license
-   and the contributor and source code lines above.
+The contributor licenses you to do everything with this
+software that would otherwise infringe their copyright
+in it.
 
-5. Do not make any legal claim against anyone accusing this
-   software, with or without changes, alone or with other
-   software, of infringing any patent claim.
+## Notices
 
-To contribute software, publish all its source code, in the
-preferred form for making changes, through a freely accessible
-distribution system widely used for similar source code, and
-license contributions not already licensed to the public on terms
-as permissive as this license accordingly.
+You must ensure that everyone who gets a copy of any
+part of this software from you, with or without changes,
+also gets the text of this license and the contributor
+and source code lines above.
 
-You are excused for unknowingly breaking 1, 2, or 3 if you
-contribute as required, or stop doing anything requiring this
-license, within 30 days of learning you broke the rule.
+## Patent
 
-**As far as the law allows, this software comes as is, without
-any warranty, and the contributor will not be liable to anyone
-for any damages related to this software or this license, for any
-kind of legal claim.**
+The contributor licenses you to do everything with this
+software that would otherwise infringe any patent claims
+they can license or become able to license.
+
+## Defense
+
+Do not make any legal claim against anyone accusing this
+software, with or without changes, alone or with other
+software, of infringing any patent claim.
+
+## Reliability
+
+The contributor cannot revoke this license.
+
+## Copyleft
+
+With the exception of prototypes:
+
+1.  Contribute all changes and additions you make to
+    this software
+
+2.  If you combine this software with other software,
+    contribute that software.
+
+3.  Contribute software you develop, deploy, monitor,
+    or run with this software.
+
+4.  When in doubt, contribute the software.
+
+## Prototypes
+
+You need not contribute prototype changes, extensions,
+or other software that you do not end up using for more
+than fourteen calendar days, sharing with anyone else,
+or using to provide a service to anyone else.
+
+## Contributing
+
+When this license requires you to contribute software:
+
+1.  Publish all source code for that software, in the
+    preferred form for making changes, through a freely
+    accessible distribution system widely used for similar
+    source code, so the contributors and others can find
+    and copy it.
+
+2.  Ensure that each part of that source code is available
+    to the public under a license at least as permissive
+    as this one.
+
+3.  Take these steps within thirty calendar days of
+    creating or using the software for the first time.
+
+Note that this license does _not_ allow you to change the
+license terms for this software, but only to contribute
+software covered by copyleft under qualifying licenses.
+
+## Excuse
+
+You are excused for unknowingly breaking
+[Copyleft](#copyleft) if you contribute as required, or
+stop doing anything requiring this license, within thirty
+days of learning you broke the rule.
+
+## No Liability
+
+***As far as the law allows, this software comes as is,
+without any warranty or condition, and the contributor
+will be liable to anyone for any damages related to this
+software or this license, under any kind of legal claim.***

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -58,7 +58,7 @@ When this license requires you to contribute:
 
 3.  Take these steps within thirty calendar days of when you first did anything requiring contribution.
 
-Note that this license does _not_ allow you to change the license terms for this software, but only to contribute software covered by copyleft under qualifying licenses.
+Note that this license does _not_ allow you to change the license terms for this software, but only to contribute software covered by [Copyleft](#copyleft) under qualifying licenses.
 
 ## Excuse
 

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -82,7 +82,7 @@ When this license requires you to contribute software:
 2.  Ensure that each part of that source code is available
     to the public under a license at least as permissive
     as this one, such as MIT, two-clause BSD license,
-    Apache 2.0, Charity 3.0.0, or Blue Oak Model.
+    Apache 2.0, Charity 3.0.0, or Blue Oak Model 1.0.0.
 
 3.  Take these steps within thirty calendar days of
     when you first did anything with the software requiring

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -6,42 +6,27 @@ Source Code: {{{source}}}
 
 ## Purpose
 
-This license lets you use and share this software for
-free, as long as you contribute software you make with it,
-other than prototypes.
+This license lets you use and share this software for free, as long as you contribute software you make with it, other than prototypes.
 
 ## Acceptance
 
-In order to receive this license, you must agree to its
-rules.  The rules of this license are both obligations
-under that agreement and conditions to your license.
-You must not do anything with this software that triggers
-a rule that you cannot or will not follow.
+In order to receive this license, you must agree to its rules.  The rules of this license are both obligations under that agreement and conditions to your license.  You must not do anything with this software that triggers a rule that you cannot or will not follow.
 
 ## Copyright
 
-The contributor licenses you to do everything with this
-software that would otherwise infringe their copyright
-in it.
+The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.
 
 ## Notices
 
-You must ensure that everyone who gets a copy of any
-part of this software from you, with or without changes,
-also gets the text of this license and the contributor
-and source code lines above.
+You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license and the contributor and source code lines above.
 
 ## Patent
 
-The contributor licenses you to do everything with this
-software that would otherwise infringe any patent claims
-they can license or become able to license.
+The contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.
 
 ## Defense
 
-Do not make any legal claim against anyone accusing this
-software, with or without changes, alone or with other
-software, of infringing any patent claim.
+Do not make any legal claim against anyone accusing this software, with or without changes, alone or with other software, of infringing any patent claim.
 
 ## Reliability
 
@@ -51,58 +36,34 @@ The contributor cannot revoke this license.
 
 With the exception of prototypes:
 
-1.  Contribute all changes and additions you make to
-    this software
+1.  Contribute all changes and additions you make to this software
 
-2.  If you combine this software with other software,
-    contribute that software.
+2.  If you combine this software with other software, contribute that software.
 
-3.  Contribute software you develop, deploy, monitor,
-    or run with this software.
+3.  Contribute software you develop, deploy, monitor, or run with this software.
 
 4.  When in doubt, contribute the software.
 
 ## Prototypes
 
-You need not contribute prototype changes, extensions, or
-other software that you do not end up using for more than
-thirty calendar days, sharing outside the development team
-working on the prototype, or using to provide a service
-to anyone else.
+You need not contribute prototype changes, extensions, or other software that you do not end up using for more than thirty calendar days, sharing outside the development team working on the prototype, or using to provide a service to anyone else.
 
 ## Contributing
 
 When this license requires you to contribute software:
 
-1.  Publish all source code for that software, in the
-    preferred form for making changes, through a freely
-    accessible distribution system widely used for similar
-    source code, so the contributors and others can find
-    and copy it.
+1.  Publish all source code for that software, in the preferred form for making changes, through a freely accessible distribution system widely used for similar source code, so the contributors and others can find and copy it.
 
-2.  Ensure that each part of that source code is available
-    to the public under a license at least as permissive
-    as this one, such as MIT, two-clause BSD license,
-    Apache 2.0, Charity 3.0.0, or Blue Oak Model 1.0.0.
+2.  Ensure that each part of that source code is available to the public under a license at least as permissive as this one, such as MIT, two-clause BSD license, Apache 2.0, Charity 3.0.0, or Blue Oak Model 1.0.0.
 
-3.  Take these steps within thirty calendar days of
-    when you first did anything with the software requiring
-    this license.
+3.  Take these steps within thirty calendar days of when you first did anything with the software requiring this license.
 
-Note that this license does _not_ allow you to change the
-license terms for this software, but only to contribute
-software covered by copyleft under qualifying licenses.
+Note that this license does _not_ allow you to change the license terms for this software, but only to contribute software covered by copyleft under qualifying licenses.
 
 ## Excuse
 
-You are excused for unknowingly breaking
-[Copyleft](#copyleft) if you contribute as required, or
-stop doing anything requiring this license, within thirty
-days of learning you broke the rule.
+You are excused for unknowingly breaking [Copyleft](#copyleft) if you contribute as required, or stop doing anything requiring this license, within thirty days of learning you broke the rule.
 
 ## No Liability
 
-***As far as the law allows, this software comes as is,
-without any warranty or condition, and the contributor
-will be liable to anyone for any damages related to this
-software or this license, under any kind of legal claim.***
+***As far as the law allows, this software comes as is, without any warranty or condition, and the contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -46,7 +46,7 @@ With the exception of prototypes:
 
 ## Prototypes
 
-You need not contribute prototype changes, extensions, or other software that you do not end up using for more than thirty calendar days, sharing outside the development team working on the prototype, or using to provide a service to anyone else.
+You need not contribute prototype changes, additions, or other software that you do not end up using for more than thirty calendar days, sharing outside the development team working on the prototype, or using to provide a service to anyone else.
 
 ## Contributing
 

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -42,7 +42,7 @@ With the exception of prototypes:
 
 3.  Contribute other software you develop, deploy, monitor, or run with this software.
 
-4.  When in doubt, contribute the software.
+4.  When in doubt, contribute.
 
 ## Prototypes
 
@@ -50,13 +50,13 @@ You need not contribute prototype changes, additions, or other software that you
 
 ## Contributing
 
-When this license requires you to contribute software:
+When this license requires you to contribute:
 
-1.  Publish all source code for that software, in the preferred form for making changes, through a freely accessible distribution system widely used for similar source code, so the contributors and others can find and copy it.
+1.  Publish all source code, in the preferred form for making changes, through a freely accessible distribution system widely used for similar source code, so the contributors and others can find and copy it.
 
 2.  Ensure that each part of that source code is available to the public under a license at least as permissive as this one, such as MIT, two-clause BSD license, Apache 2.0, Charity 3.0.0, or Blue Oak Model 1.0.0.
 
-3.  Take these steps within thirty calendar days of when you first did anything with the software requiring this license.
+3.  Take these steps within thirty calendar days of when you first did anything requiring contribution.
 
 Note that this license does _not_ allow you to change the license terms for this software, but only to contribute software covered by copyleft under qualifying licenses.
 

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -81,7 +81,8 @@ When this license requires you to contribute software:
 
 2.  Ensure that each part of that source code is available
     to the public under a license at least as permissive
-    as this one.
+    as this one, such as MIT, two-clause BSD license,
+    Apache 2.0, Charity 3.0.0, or Blue Oak Model.
 
 3.  Take these steps within thirty calendar days of
     creating or using the software for the first time.

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -85,7 +85,8 @@ When this license requires you to contribute software:
     Apache 2.0, Charity 3.0.0, or Blue Oak Model.
 
 3.  Take these steps within thirty calendar days of
-    creating or using the software for the first time.
+    when you first did anything with the software requiring
+    this license.
 
 Note that this license does _not_ allow you to change the
 license terms for this software, but only to contribute

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -64,10 +64,11 @@ With the exception of prototypes:
 
 ## Prototypes
 
-You need not contribute prototype changes, extensions,
-or other software that you do not end up using for more
-than thirty calendar days, sharing with anyone else,
-or using to provide a service to anyone else.
+You need not contribute prototype changes, extensions, or
+other software that you do not end up using for more than
+thirty calendar days, sharing outside the development team
+working on the prototype, or using to provide a service
+to anyone else.
 
 ## Contributing
 

--- a/THANKS.md
+++ b/THANKS.md
@@ -5,3 +5,4 @@
 - Jeremy W. Sherman, [@jeremy-w](https://github.com/jeremy-w)
 - Markus Binsteiner, [@makkus](https://github.com/makkus)
 - Luis Villa [@tieguy](https://github.com/tieguy)
+- Kat Marchán [@zkat](https://github.com/zkat)


### PR DESCRIPTION
This PR contains a rewrite and revision of Parity 6.0.0, starting from current `master` of [The API Copyleft License](https://github.com/kemitchell/api-copyleft-license).  Some may recognize the style and format more from [The Blue Oak Model License](https://blueoakcouncil.org/license/1.0.0).

The license is longer this way. Given the section structure, I think it will tend to get longer still, since it's easier to drop in clarifications. But I also suspect this is more readable. Parity directly inspired API Copyleft, which in turn influenced Blue Oak, all of which served as starting points for the Polyform Project licenses. I was not alone on any of those terms, and they've improved in time with more feedback, from lawyers and _especially_ non-lawyers.

The major substantive change here is the addition of a Prototypes section along the lines of API Copyleft. That term essentially says that you don't have to publish and license source code for experiments. Frankly, I think that term would do more to affect perception of Parity than its practical effect. But perception of Parity correctly identifies it as an aggressive set of terms, and I think a rule like Prototypes can help soften that perceived harshness. Parity was never a "gotcha" license. Perhaps this way, that will be more clear to more people.

@zkat gave the private feedback that finally got me to sketch this out, but it's brewing a long time, based on feedback from others. @makkus comes to mind, but I'm sure he wasn't the only one.

@zkat, I'd like to take this opportunity to work on clarifying for use cases like srisum, too. Perhaps I could coaxe you into giving us a short comment outlining what srisum is, and why the current Parity contribution rules, which are still a part of this rewrite, fail to cover it adequately?