### PR TITLE
Simplify Copyleft

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -36,19 +36,11 @@ The contributor cannot revoke this license.
 
 ## Copyleft
 
-With the exception of [prototypes](#prototypes):
-
-1.  [Contribute](#contributing) all changes and additions you make to this software.
-
-2.  If you combine this software with other software, [contribute](#contributing) that software.
-
-3.  [Contribute](#contributing) other software you develop, deploy, monitor, or run with this software.
-
-4.  When in doubt, [contribute](#contributing).
+[Contribute](#contributing) software that you develop, deploy, monitor, or run with this software, including changed or extended versions of this software.  When in doubt, [contribute](#contributing).
 
 ## Prototypes
 
-You need not [contribute](#contributing) prototype changes, additions, or other software that you do not end up using for more than thirty calendar days, sharing outside the development team working on the prototype, or using to provide a service to anyone else.
+You do not have to [contribute](#contributing) prototypes that you do not end up using for more than thirty calendar days, sharing outside the development team working on the prototype, or using to provide a service to anyone else.
 
 ## Contributing
 

--- a/tests/copyleft.md
+++ b/tests/copyleft.md
@@ -1,0 +1,167 @@
+# Copyleft Test Cases
+
+Jump To: [Applications](#applications), [Components](#components), [Development Tools](#development-tools), [Platforms](#platforms)
+
+## Applications
+
+### Standalone Applications
+
+- Inkscape
+  - images created
+  - plugins
+
+- Signal
+
+### Plugins
+
+- Adblock Plus
+
+### Server Applications
+
+- NGINX
+  - modules
+  - web applications
+
+- WordPress
+  - plugins
+  - themes
+
+### Client Applications
+
+- Firefox
+  - web applications
+  - plugins
+  - extensions
+
+### Peer-to-Peer Applications
+
+- Bittorrent
+
+- Ethereum
+  - smart contracts
+
+## Components
+
+### Libraries
+
+- jQuery
+  - web applications
+
+- mongo-c-driver
+  - server applications
+
+- OpenSSL
+  - client applications
+  - server applications
+
+### Frameworks
+
+- Ruby on Rails
+  - web applications
+  - plugins
+  - themes
+
+- Ember
+  - web applications
+  - plugins
+  - themes
+
+- Cordova
+  - applications
+
+### Services
+
+- PostgreSQL
+  - applications
+
+- Network Time Protocol Daemon
+
+## Development Tools
+
+### Editors
+
+- Emacs
+  - source code written
+
+- Eclipse
+  - source code written
+
+### Generators
+
+- Bison
+  - generated code
+
+- WebPack
+  - packaged code
+
+- UglifyJS
+  - uglified code
+
+### Analyzers
+
+- ESLint
+  - analyzed code
+
+- Frama-C
+  - analyzed code
+
+### Compilers
+
+- GCC
+  - compiled code
+  - extensions
+  - front ends
+
+- LLVM
+  - compiled code
+  - extensions
+  - front ends
+
+### Debuggers
+
+- GDB
+  - debugged binaries
+
+### Package Managers
+
+- npm
+  - developed projects
+
+- RPM
+
+### Revision Control Systems
+
+- Git
+  - tracked code
+
+- GitLab
+  - tracked code
+
+## Platforms
+
+### Operating Systems
+
+- Linux
+  - drivers
+  - modules
+
+### Base Systems
+
+- GNU coreutils
+  - scripts invoking
+
+- Busybox
+  - scripts invoking
+
+### Interpreters
+
+- Python
+  - scripts run
+
+### Orchestrators
+
+- Chef
+  - software deployed
+
+- Kubernetes
+  - software deployed

--- a/tests/copyleft.md
+++ b/tests/copyleft.md
@@ -160,7 +160,9 @@ Jump To: [Applications](#applications), [Components](#components), [Development 
 
 ### Orchestrators
 
-- Chef
+- Ansible
+  - roles
+  - modules
   - software deployed
 
 - Kubernetes


### PR DESCRIPTION
This PR begins the process of simplifying the copyleft rules. The major insight here is that old rules 1 (changes, additions) and 2 (combinations) were really just special cases of rule 3 (develop, deploy, monitor, run).

The new copyleft rule focuses in on old rule 3. I am still interested in finding an abstraction that covers "develop, deploy, monitor, or run". Other folks have posted great links to various overviews of the "dev ops" lifecycle.