### PR TITLE
Use "develop, study, or operate" throughout

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -14,13 +14,13 @@ This license lets you use and share this software for free, as long as you contr
 
 In order to receive this license, you must agree to its rules.  The rules of this license are both obligations under that agreement and conditions to your license.  You must not do anything with this software that triggers a rule that you cannot or will not follow.
 
-## Copyright
-
-The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.
-
 ## Notices
 
 You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license and the contributor and source code lines above.
+
+## Copyright
+
+The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.
 
 ## Patent
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -42,7 +42,7 @@ When this license requires you to [contribute](#contributing):
 
 3.  Take these steps within thirty calendar days of when you first did anything triggering a rule requiring [contribution](#contributing).
 
-Note that this license does _not_ allow you to change the license terms for this software.
+4.  Note that this license does _not_ allow you to change the license terms for this software.
 
 ## Defense
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -18,22 +18,6 @@ In order to receive this license, you must agree to its rules.  The rules of thi
 
 You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license and the contributor and source code lines above.
 
-## Copyright
-
-The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.
-
-## Patent
-
-The contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.
-
-## Defense
-
-Do not make any legal claim against anyone accusing this software, with or without changes, alone or with other software, of infringing any patent claim.
-
-## Reliability
-
-The contributor cannot revoke this license.
-
 ## Copyleft
 
 [Contribute](#contributing) software that you develop, study, or operate with this software, including changed or extended versions of this software.  When in doubt, [contribute](#contributing).
@@ -59,6 +43,22 @@ When this license requires you to [contribute](#contributing):
 3.  Take these steps within thirty calendar days of when you first did anything requiring [contribution](#contributing).
 
 Note that this license does _not_ allow you to change the license terms for this software.
+
+## Copyright
+
+The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.
+
+## Patent
+
+The contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.
+
+## Defense
+
+Do not make any legal claim against anyone accusing this software, with or without changes, alone or with other software, of infringing any patent claim.
+
+## Reliability
+
+The contributor cannot revoke this license.
 
 ## Excuse
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -12,7 +12,7 @@ This license lets you use and share this software for free, as long as you contr
 
 ## Acceptance
 
-In order to receive this license, you must agree to its rules.  The rules of this license are both obligations under that agreement and conditions to your license.  You must not do anything with this software that triggers a rule that you cannot or will not follow.
+In order to receive this license, you must agree to its rules.  Those rules are both obligations under that agreement and conditions to your license.  You must not do anything with this software that triggers a rule that you cannot or will not follow.
 
 ## Notices
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -20,7 +20,7 @@ You must ensure that everyone who gets a copy of any part of this software from 
 
 ## Copyleft
 
-[Contribute](#contributing) software that you develop, study, or operate with this software, including changed or extended versions of this software.  When in doubt, [contribute](#contributing).
+[Contribute](#contributing) software that you develop, study, or operate with this software, including changes or additions to this software.  When in doubt, [contribute](#contributing).
 
 ## Prototypes
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -40,7 +40,7 @@ When this license requires you to [contribute](#contributing):
 
 2.  Ensure that each part of that source code is available to the public under a license at least as permissive as this one, such as MIT, two-clause BSD license, Apache 2.0, or Blue Oak Model 1.0.0.
 
-3.  Take these steps within thirty calendar days of when you first did anything requiring [contribution](#contributing).
+3.  Take these steps within thirty calendar days of when you first did anything triggering a rule requiring [contribution](#contributing).
 
 Note that this license does _not_ allow you to change the license terms for this software.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,7 +8,7 @@ Source Code: {{{source}}}
 
 ## Purpose
 
-This license lets you use and share this software for free, as long as you contribute software you make with it, other than prototypes.
+This license lets you use and share this software for free, as long as you contribute software you develop, study, or operate with it, other than prototypes.
 
 ## Acceptance
 
@@ -36,7 +36,7 @@ The contributor cannot revoke this license.
 
 ## Copyleft
 
-[Contribute](#contributing) software that you develop, deploy, monitor, or run with this software, including changed or extended versions of this software.  When in doubt, [contribute](#contributing).
+[Contribute](#contributing) software that you develop, study, or operate with this software, including changed or extended versions of this software.  When in doubt, [contribute](#contributing).
 
 ## Prototypes
 
@@ -46,7 +46,7 @@ You need not [contribute](#contributing) any change, addition, or other software
 
 2.  You do not share it outside the development team working on the prototype.
 
-3.  You do not use it to develop or operate software for anyone outside the development team.
+3.  You do not use it to develop, study, or operate software for anyone outside the development team.
 
 ## Contributing
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -44,6 +44,10 @@ When this license requires you to [contribute](#contributing):
 
 Note that this license does _not_ allow you to change the license terms for this software.
 
+## Defense
+
+Do not make any legal claim against anyone accusing this software, with or without changes, alone or with other software, of infringing any patent claim.
+
 ## Copyright
 
 The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.
@@ -51,10 +55,6 @@ The contributor licenses you to do everything with this software that would othe
 ## Patent
 
 The contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.
-
-## Defense
-
-Do not make any legal claim against anyone accusing this software, with or without changes, alone or with other software, of infringing any patent claim.
 
 ## Reliability
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -36,7 +36,7 @@ You need not [contribute](#contributing) any change, addition, or other software
 
 When this license requires you to [contribute](#contributing):
 
-1.  Publish all source code, in the preferred form for making changes, through a freely accessible distribution system widely used for similar source code, so the or and others can find and copy it.
+1.  Publish all source code, in the preferred form for making changes, through a freely accessible distribution system widely used for similar source code, so the contributor and others can find and copy it.
 
 2.  Ensure that each part of that source code is available to the public under a license at least as permissive as this one, such as MIT, two-clause BSD license, Apache 2.0, or Blue Oak Model 1.0.0.
 


### PR DESCRIPTION
This PR changes language about the scope of copyleft to use "develop, study, or operate" throughout.

This is much inspired by recent comments from @christianbundy, @bradrydzewski, @makkus. See especially #57.

My main concern here is making sure that "operate" clearly points to the "op" in "devops". Not sure that would be clear to a nontechnical person without that context.

Also slightly worried that "devops" is very buzzword-y. If we rely on it, it may shift out from under us.