### PR TITLE
Avoid permission

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,7 +8,7 @@ Source Code: {{{uri}}}
 
 ## Purpose
 
-This license lets you use and share this software for free, as long as you contribute software you develop, operate, or analyze with it.
+This license allows you to use and share this software for free, as long as you contribute software you develop, operate, or analyze with it.
 
 ## Acceptance
 
@@ -42,7 +42,7 @@ When this license requires you to [contribute](#contribute) software:
 
 3.  Take these steps within thirty days.
 
-4.  Note that this license does _not_ let you to change the license terms for this software.
+4.  Note that this license does _not_ allow you to change the license terms for this software.
 
 ## Excuse
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -42,7 +42,7 @@ When this license requires you to [contribute](#contribute) software:
 
 3.  Take these steps within thirty days.
 
-4.  Note that this license does _not_ allow you to change the license terms for this software.
+4.  Note that this license does _not_ let you to change the license terms for this software.
 
 ## Excuse
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -38,7 +38,7 @@ When this license requires you to [contribute](#contribute) software:
 
 1.  Publish all source code for the software, in the preferred form for making changes, through a freely accessible distribution system widely used for similar source code, so the contributor and others can find and copy it.
 
-2.  Make sure each part of the source code is available to the public under a license that gives as much or more permission as this one, such as [Blue Oak Model 1.0.0](https://blueoakcouncil.org/license/1.0.0), [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html), [MIT](https://spdx.org/licenses/MIT.html), or [two-clause BSD](https://spdx.org/licenses/BSD-2-Clause.html).
+2.  Make sure each part of the source code is available under this license or another license that allows everything this license does, such as [Blue Oak Model 1.0.0](https://blueoakcouncil.org/license/1.0.0), [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html), [MIT](https://spdx.org/licenses/MIT.html), or [two-clause BSD](https://spdx.org/licenses/BSD-2-Clause.html).
 
 3.  Take these steps within thirty days.
 


### PR DESCRIPTION
cc @jeremy-w 

Took a stab at rewriting the license rule under Contributing again.

I ended up really wanting "allow", rather than "let", so I changed to "allow" throughout the license. The word "allow" is less frequent in English than "let", but still within the top 350 according to wordfrequency.info, and way more common than "permit" or "license".