### PR TITLE
Rewrite Purpose

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,7 +8,7 @@ Source Code: {{{uri}}}
 
 ## Purpose
 
-This license allows you to use and share this software for free.  But you must share software that building on it alike.
+This license allows you to use and share this software for free.  But you must share software that builds on it alike.
 
 ## Acceptance
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,7 +8,7 @@ Source Code: {{{uri}}}
 
 ## Purpose
 
-This license allows you to use and share this software for free.  However, you must share other software building upon it alike.
+This license allows you to use and share this software for free.  However, you must share other software building on it alike.
 
 ## Acceptance
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,7 +8,7 @@ Source Code: {{{uri}}}
 
 ## Purpose
 
-This license allows you to use and share this software for free, as long as you contribute software you develop, operate, or analyze with it.
+This license allows you to use and share this software for free, as long as you contribute software you build with it alike.
 
 ## Acceptance
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,7 +8,7 @@ Source Code: {{{uri}}}
 
 ## Purpose
 
-This license allows you to use and share this software for free.  However, if you build other software upon it, you must share alike.
+This license allows you to use and share this software for free.  However, you must share other software building upon it alike.
 
 ## Acceptance
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,7 +8,7 @@ Source Code: {{{uri}}}
 
 ## Purpose
 
-This license allows you to use and share this software for free, as long as you contribute software you build with it alike.
+This license allows you to use and share this software for free.  However, if you build other software upon it, you must share alike.
 
 ## Acceptance
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,7 +8,7 @@ Source Code: {{{uri}}}
 
 ## Purpose
 
-This license allows you to use and share this software for free.  However, you must share other software building on it alike.
+This license allows you to use and share this software for free.  But you must share software that building on it alike.
 
 ## Acceptance
 


### PR DESCRIPTION
This PR replaces the Purpose statement with a shorter summary more reminiscent of Parity 6.

The triplet "develop, operate, analyze" is definitely the core of the copyleft rule. But the Purpose is meant to be a short _summary_ of the license, not an incomplete sampling of its terms.

A shorter summary actually helps readers developer understanding gradually. On the legal side, a broader statement of purpose also helps courts in the event of an ambiguity in application, by giving them a more general statement of purpose to fall back on.