### PR TITLE
Avoid using "license" as a verb (close #78)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -56,11 +56,11 @@ Don't make any legal claim against anyone accusing this software, with or withou
 
 ## Copyright
 
-The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.
+The contributor gives you license to do everything with this software that would otherwise infringe their copyright in it.
 
 ## Patent
 
-The contributor licenses you to do everything with this software that would otherwise infringe any patents they can license or become able to license.
+The contributor gives you license to do everything with this software that would otherwise infringe any patents they can license or become able to license.
 
 ## Reliability
 


### PR DESCRIPTION
Responsive to @skullbunnygalaxy's feedback on readability.

This language differs just slightly from [my comment](https://github.com/licensezero/parity-public-license/issues/78#issuecomment-1019537795) to #78. I'm using "gives you license" instead of "gives you a license" to stay consistent with the rest of the terms, which refer to "this license", "your license", and so on. I don't want to confuse anyone by talking about a license---the whole document---comprised of more licenses---for copyright and patent.